### PR TITLE
Fix parsing with only exploitable videos

### DIFF
--- a/parseAnnotations.py
+++ b/parseAnnotations.py
@@ -200,7 +200,15 @@ class AnnotationParser:
 
         def splitKeypointValues(x):
             "Convert annotation info to a Series with the keys and values"
-            return pd.Series(x).rename(index=dict(zip(self.labels['class'], self.labels['aname'])))
+            class_to_aname = dict(zip(self.labels['class'], self.labels['aname']))
+            aname_to_class = dict(zip(self.labels['aname'], self.labels['class']))
+
+            # Explicitly converts (no value in JSON) to (NaN in Python)
+            # for Exploitable videos. If not, column won't be created
+            if aname_to_class['exploitable'] not in x:
+                x[aname_to_class['exploitable']] = float('nan')
+
+            return pd.Series(x).rename(index=class_to_aname)
 
         DFS = [
                d['av'].apply(splitKeypointValues), # annotation info

--- a/test/test_3_videos_only_exploitable.json
+++ b/test/test_3_videos_only_exploitable.json
@@ -1,0 +1,340 @@
+{
+  "project": {
+    "pid": "ef58b6de-e5d4-4c17-b3fa-d343bc22b6bb",
+    "rev": "4",
+    "rev_timestamp": "1573701459573",
+    "pname": "PyroNear v1",
+    "creator": "VGG Image Annotator (http://www.robots.ox.ac.uk/~vgg/software/via)",
+    "created": 1573528275049,
+    "vid_list": [
+      "1",
+      "2",
+      "3"
+    ]
+  },
+  "config": {
+    "file": {
+      "loc_prefix": {
+        "1": "",
+        "2": "",
+        "3": "",
+        "4": ""
+      }
+    },
+    "ui": {
+      "file_content_align": "center",
+      "file_metadata_editor_visible": true,
+      "spatial_metadata_editor_visible": true,
+      "spatial_region_label_attribute_id": ""
+    }
+  },
+  "attribute": {
+    "1": {
+      "aname": "fire",
+      "anchor_id": "FILE1_Z1_XY1",
+      "type": 3,
+      "desc": "",
+      "options": {
+        "0": "0",
+        "1": "1"
+      },
+      "default_option_id": "1"
+    },
+    "3": {
+      "aname": "sequence",
+      "anchor_id": "FILE1_Z1_XY1",
+      "type": 4,
+      "desc": "",
+      "options": {
+        "0": "1",
+        "1": "2",
+        "2": "3",
+        "3": "4",
+        "4": "5",
+        "5": "6",
+        "6": "7",
+        "7": "8",
+        "8": "9",
+        "9": "10"
+      },
+      "default_option_id": "0"
+    },
+    "4": {
+      "aname": "spatial",
+      "anchor_id": "FILE1_Z2_XY0",
+      "type": 1,
+      "desc": "",
+      "options": {},
+      "default_option_id": ""
+    },
+    "5": {
+      "aname": "exploitable",
+      "anchor_id": "FILE1_Z0_XY0",
+      "type": 3,
+      "desc": "",
+      "options": {
+        "0": "0",
+        "1": "1"
+      },
+      "default_option_id": "1"
+    },
+    "6": {
+      "aname": "clf_confidence",
+      "anchor_id": "FILE1_Z1_XY1",
+      "type": 3,
+      "desc": "classif confidence",
+      "options": {
+        "0": "0",
+        "1": "1"
+      },
+      "default_option_id": "1"
+    },
+    "7": {
+      "aname": "loc_confidence",
+      "anchor_id": "FILE1_Z1_XY1",
+      "type": 3,
+      "desc": "location confidence",
+      "options": {
+        "0": "None",
+        "1": "0",
+        "2": "1"
+      },
+      "default_option_id": "0"
+    }
+  },
+  "file": {
+    "1": {
+      "fid": "1",
+      "fname": "10.mp4",
+      "type": 4,
+      "loc": 1,
+      "src": ""
+    },
+    "2": {
+      "fid": "2",
+      "fname": "19_seq0_591.mp4",
+      "type": 4,
+      "loc": 1,
+      "src": ""
+    },
+    "3": {
+      "fid": "3",
+      "fname": "19_seq598_608.mp4",
+      "type": 4,
+      "loc": 1,
+      "src": ""
+    }
+  },
+  "metadata": {
+    "1_b86X95gc": {
+      "vid": "1",
+      "flg": 0,
+      "z": [],
+      "xy": [],
+      "av": {}
+    },
+    "1_3Ru0wnH5": {
+      "vid": "1",
+      "flg": 0,
+      "z": [
+        1.32
+      ],
+      "xy": [
+        1,
+        598.974,
+        467.692
+      ],
+      "av": {
+        "1": "1",
+        "3": "0",
+        "4": "_DEFAULT",
+        "6": "1",
+        "7": "2"
+      }
+    },
+    "1_n8ae5uur": {
+      "vid": "1",
+      "flg": 0,
+      "z": [
+        2.826
+      ],
+      "xy": [
+        1,
+        609.231,
+        463.59
+      ],
+      "av": {
+        "1": "1",
+        "3": "0",
+        "4": "_DEFAULT",
+        "6": "1",
+        "7": "2"
+      }
+    },
+    "1_PJUqsh48": {
+      "vid": "1",
+      "flg": 0,
+      "z": [
+        15.564
+      ],
+      "xy": [
+        1,
+        873.846,
+        500.513
+      ],
+      "av": {
+        "1": "1",
+        "3": "1",
+        "4": "_DEFAULT",
+        "6": "1",
+        "7": "0"
+      }
+    },
+    "1_HgMtP1P5": {
+      "vid": "1",
+      "flg": 0,
+      "z": [
+        18.637
+      ],
+      "xy": [
+        1,
+        869.744,
+        506.667
+      ],
+      "av": {
+        "1": "1",
+        "3": "1",
+        "4": "_DEFAULT",
+        "6": "1",
+        "7": "0"
+      }
+    },
+    "1_n1HrQ2bC": {
+      "vid": "1",
+      "flg": 0,
+      "z": [
+        20.057
+      ],
+      "xy": [
+        1,
+        543.59,
+        418.462
+      ],
+      "av": {
+        "1": "0",
+        "3": "2",
+        "4": "_DEFAULT",
+        "6": "1",
+        "7": "0"
+      }
+    },
+    "1_boGYYj91": {
+      "vid": "1",
+      "flg": 0,
+      "z": [
+        19.779
+      ],
+      "xy": [
+        1,
+        724.103,
+        449.231
+      ],
+      "av": {
+        "1": "0",
+        "3": "2",
+        "4": "_DEFAULT",
+        "6": "1",
+        "7": "0"
+      }
+    },
+    "1_U2O2ISJn": {
+      "vid": "1",
+      "flg": 0,
+      "z": [
+        28.191
+      ],
+      "xy": [
+        1,
+        939.487,
+        244.103
+      ],
+      "av": {
+        "1": "1",
+        "3": "3",
+        "4": "_DEFAULT",
+        "6": "1",
+        "7": "2"
+      }
+    },
+    "1_E9Wv1ZiA": {
+      "vid": "1",
+      "flg": 0,
+      "z": [
+        38.907
+      ],
+      "xy": [
+        1,
+        957.949,
+        237.949
+      ],
+      "av": {
+        "1": "1",
+        "3": "3",
+        "4": "_DEFAULT",
+        "6": "0",
+        "7": "0"
+      }
+    },
+    "2_q7xhu0I0": {
+      "vid": "2",
+      "flg": 0,
+      "z": [],
+      "xy": [],
+      "av": {}
+    },
+    "2_Lz0wmxdc": {
+      "vid": "2",
+      "flg": 0,
+      "z": [
+        2.261
+      ],
+      "xy": [
+        1,
+        568.205,
+        358.974
+      ],
+      "av": {
+        "1": "1",
+        "3": "0",
+        "4": "_DEFAULT",
+        "6": "0",
+        "7": "2"
+      }
+    },
+    "3_48jX6WCH": {
+      "vid": "3",
+      "flg": 0,
+      "z": [],
+      "xy": [],
+      "av": {
+      }
+    }
+  },
+  "view": {
+    "1": {
+      "fid_list": [
+        "1"
+      ]
+    },
+    "2": {
+      "fid_list": [
+        "2"
+      ]
+    },
+    "3": {
+      "fid_list": [
+        "3"
+      ]
+    }
+  }
+}

--- a/test/test_parseAnnotations.py
+++ b/test/test_parseAnnotations.py
@@ -59,8 +59,11 @@ def setupTester(cls):
     Setup tester for AnnotationParser
     """
     inputJson = Path(sys.argv[0]).parent/'test_3_videos.json'
+    inputJson_only_exploitable = Path(sys.argv[0]).parent/'test_3_videos_only_exploitable.json')
     inputdir = Path('~/Workarea/Pyronear/Wildfire').expanduser()
+
     cls.parser = parseAnnotations.AnnotationParser(inputJson, inputdir=inputdir)
+    cls.parser_only_exploitable = parseAnnotations.AnnotationParser(inputJson_only_exploitable, inputdir=inputdir)
 
 class test_parseAnnotations(unittest.TestCase):
     """
@@ -70,6 +73,16 @@ class test_parseAnnotations(unittest.TestCase):
     def setUpClass(cls):
         "Setup only once for all tests"
         setupTester(cls)
+
+    def test_columns_are_right(self):
+        for col_name in self.parser.labels['aname']:
+            if col_name != 'spatial':  # spatial is expected to be dropped during the parsing
+                self.assertIn(col_name, self.parser.keypoints.columns)
+
+        # When all video are exploitable, is the column correctly created ?
+        for col_name in self.parser_only_exploitable.labels['aname']:
+            if col_name != 'spatial':  # spatial is expected to be dropped during the parsing
+                self.assertIn(col_name, self.parser_only_exploitable.keypoints.columns)
 
 
     def test_files(self):


### PR DESCRIPTION
This PR aims at solving the issue of `exploitable` column not created when the JSON only contain exploitable videos.

Indeed, in the JSON, no value means _exploitable_ and ` "0"`  means _not exploitable_
So if there are only exploitable videos, when converting to dataframe, no column is created.
The proposed fix is to convert _absence of value in JSON_ to _NaN in python_

Any feedback is welcome