### PR TITLE
Re-extract frames

### DIFF
--- a/parseAnnotations.py
+++ b/parseAnnotations.py
@@ -70,6 +70,15 @@ def pickFrames(state, nFrames, random=True, seed=42):
     - random: bool (default: True). Pick frames randomly or according to np.linspace,
       e.g. first if nFrames = 1, + last if nFrames = 2, + middle if nFrames = 3, etc
     - seed: int, seed for random picking (default: 42)
+
+    Example:
+    state = pd.Series({'stateStart': 0, 'stateEnd': 100})
+    pickFrames(state, 3, random=False)
+
+0      0
+1     50
+2    100
+dtype: int64
     """
     np.random.seed(seed)
     if random:
@@ -78,17 +87,24 @@ def pickFrames(state, nFrames, random=True, seed=42):
         return pd.Series(np.linspace(state.stateStart, state.stateEnd, nFrames, dtype=int))
 
 
-def getFrameLabels(states, nFrames, **kw):
+def getFrameLabels(states, nFrames, from_labels=False, **kw):
     """
-    Given a DataFrame with states, call pickFrames to create a DataFrame with
+    Given a DataFrame with states or labels, call pickFrames to create a DataFrame with
     nFrames per state containing the state information, filename and
     imgFile (the name of the file to be used when writing an image)
+
+    If from_labels is True, the input DataFrame should contain in addition columns
+    'frame' and 'imgFile'.
+    Ignore those columns and pick the frames again based on the new criteria
 
     Args:
     - states: DataFrame containing fBase, stateStart, stateEnd
     - nFrames: int, number of frames per state
+    - from_labels: bool, default False
     - kw: list of keyword arguments for pickFrames
     """
+    if from_labels:
+        states = states.drop(columns=['frame', 'imgFile']).drop_duplicates()
     fcn = partial(pickFrames, nFrames=nFrames, **kw)
     # DataFrame containing columns (0..nFrames - 1)
     frames = states.apply(fcn, axis=1)

--- a/parseAnnotations.py
+++ b/parseAnnotations.py
@@ -101,9 +101,9 @@ def getFrameLabels(states, nFrames, **kw):
     return df.sort_values(['fBase', 'frame'])
 
 
-def writeFrames(labels, inputdir, outputdir):
+def extractFrames(labels, inputdir, outputdir):
     """
-    Extract frames from <inputfile>/<fBase> and write frames as
+    Extract frames from <inputdir>/<fBase> and write frames as
     <outputdir>/<fBase>_frame<frame>.png
 
     Args:
@@ -277,7 +277,7 @@ class AnnotationParser:
 
         # Write frames
         print(f'Extracting {nFrames} frames per state ({len(labels)} in total) to {outputdir}')
-        writeFrames(labels, self.inputdir, outputdir)
+        extractFrames(labels, self.inputdir, outputdir)
 
 
 if __name__ == '__main__':

--- a/test/test_parseAnnotations.py
+++ b/test/test_parseAnnotations.py
@@ -101,7 +101,7 @@ def setupTester(cls):
     Setup tester for AnnotationParser
     """
     inputJson = Path(sys.argv[0]).parent / 'test_3_videos.json'
-    inputJson_only_exploitable = Path(sys.argv[0]).parent/'test_3_videos_only_exploitable.json'
+    inputJson_only_exploitable = Path(sys.argv[0]).parent / 'test_3_videos_only_exploitable.json'
     inputdir = Path('~/Workarea/Pyronear/Wildfire').expanduser()
 
     cls.parser = parseAnnotations.AnnotationParser(inputJson, inputdir=inputdir)


### PR DESCRIPTION
New feature: ability to re-extract frames.

This is particularly useful for checking the movie annotations and then re-extract the frames based on the corrected labels and/or a new strategy (e.g.: use the first and last frame of each state for checking and randomly pick 3 frames per state for training).
