### PR TITLE
fix: issue in JSON parsing for xy columns

### DIFF
--- a/parseAnnotations.py
+++ b/parseAnnotations.py
@@ -213,7 +213,7 @@ class AnnotationParser:
 
         DFS = [
             d['av'].apply(splitKeypointValues),  # annotation info
-            pd.DataFrame(d.xy.tolist(), columns=['dummy', 'x', 'y']),  # split xy
+            pd.DataFrame([xy[0:3] for xy in d.xy.tolist()], columns=['dummy', 'x', 'y']),  # split xy
             pd.DataFrame(d.z.tolist(), columns=['t']),  # time of keypoint
         ]
         d = d.join(DFS).drop(columns=['fid', 'xy', 'av', 'dummy', 'vid', 'z', 'spatial'])\


### PR DESCRIPTION
xy points may have more than 3 values, which is due to a bug in annotations files. 
I limited the number of possible values in xy list to 3 elements as expected in dataframe columns.
(i.e 5 values in row 2, column' xy' below)
<img width="1025" alt="Capture d’écran 2020-04-02 à 18 08 40" src="https://user-images.githubusercontent.com/55509694/78282531-bb4ad880-751c-11ea-96a1-7222a915ecbf.png">
