### PR TITLE
fix #9 by returning a string instead of Path object to the downloader

### DIFF
--- a/test/test_parseAnnotations.py
+++ b/test/test_parseAnnotations.py
@@ -80,7 +80,8 @@ def setupTester(cls):
             vid = pafy.new(url)
             stream = vid.getbest()
             print(f'Downloading {stream.get_filesize()/1e6:.2f} MB')
-            stream.download(filepath=(cls.inputdir / dest).as_posix())
+            # youtube-dl behind pafy does not support Pathlib objects, str is okay
+            stream.download(filepath=str(cls.inputdir / dest))
 
     Parser = parseAnnotations.AnnotationParser
     cls.parser = Parser(inputJson, inputdir=cls.inputdir)

--- a/test/test_parseAnnotations.py
+++ b/test/test_parseAnnotations.py
@@ -80,7 +80,7 @@ def setupTester(cls):
             vid = pafy.new(url)
             stream = vid.getbest()
             print(f'Downloading {stream.get_filesize()/1e6:.2f} MB')
-            stream.download(cls.inputdir / dest)
+            stream.download(filepath=(cls.inputdir / dest).as_posix())
 
     Parser = parseAnnotations.AnnotationParser
     cls.parser = Parser(inputJson, inputdir=cls.inputdir)


### PR DESCRIPTION
Hi, this PR should fix #9 

Tests now should pass:
`python -m unittest test/test_parseAnnotations.py`

Thanks for reviewing